### PR TITLE
Fix for twemproxy tar

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name    'puppet-twemproxy'
-version '1.1.6'
+version '1.1.7'
 source  'git@github.com:MSMFG/puppet-twemproxy.git'
 author  'Paul Gilligan <Paul.Gilligan@moneysupermarket.com>'
 license 'Apache-2.0'

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppet-twemproxy",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "author": "Paul Gilligan <Paul.Gilligan@moneysupermarket.com>",
   "summary": "This module installs and configures Twemproxy.",
   "license": "Apache-2.0",


### PR DESCRIPTION
- [x] unpacks to /usr/local/src/twemproxy-0.4.1 instead of /usr/local/src/nutcracker-0.4.1

Error from the puppet run...>
14:07:10: [1;31mError: Working directory '/usr/local/src/twemproxy-0.4.1' does not exist[0m
14:07:10: [1;31mError: /Stage[main]/Twemproxy::Install/Exec[autoconf-twemproxy-0.4.1]/returns: change from notrun to 0 failed: Working directory '/usr/local/src/twemproxy-0.4.1' does not exist[0m