### PR TITLE
Working version of twemproxy 0.4.1 including mbuf toggle ability

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name    'puppet-twemproxy'
-version '1.1.7'
+version '1.1.8'
 source  'git@github.com:MSMFG/puppet-twemproxy.git'
 author  'Paul Gilligan <Paul.Gilligan@moneysupermarket.com>'
 license 'Apache-2.0'

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Puppet-twemproxy
 
 This module manages [twemproxy](http://www.github.com/twitter/twemproxy) package installation from source. It is based on and compatible with [puppet-twemproxy](https://forge.puppetlabs.com/wuakitv/twemproxy).
 
-The support version of twemproxy is 0.4.0 to take advantage of various improvements and in addtion working tests and addtional stats parameters have been added. 
+The support version of twemproxy is 0.4.1 to take advantage of various improvements and in addtion working tests and addtional stats parameters have been added.
 
 > Currently acceptance test using centos 6.5
 
@@ -20,7 +20,7 @@ The support version of twemproxy is 0.4.0 to take advantage of various improveme
           auto_eject_hosts     => true,
 
           verbosity            => 11,
-          
+
           log_dir              => '/var/log/nutcracker',
           pid_dir              => '/var/run/nutcracker',
           redis                => true,
@@ -28,27 +28,28 @@ The support version of twemproxy is 0.4.0 to take advantage of various improveme
           statsaddress         => '127.0.0.1',
           statsport            => 22222,
           statsinterval        => 10000,
+          mbuf                 => 16384, # default 16384 bytes recommend 512 bytes
 
           members              =>  [
-           { 
+           {
               'ip'         => 'myhost6390.domain',
               'name'       => 'redis-6390',
               'redis_port' => '6390',
               'weight'     => '1'
             },
-            { 
+            {
               'ip'         => 'myhost6391.domain',
               'name'       => 'redis-6391',
               'redis_port' => '6391',
               'weight'     => '1'
             },
-            { 
+            {
               'ip'         => 'myhost6391.domain',
               'name'       => 'redis-6392',
               'redis_port' => '6392',
               'weight'     => '1'
             }
-          ] 
+          ]
         }    
 ```
 

--- a/manifests/resource/nutcracker4.pp
+++ b/manifests/resource/nutcracker4.pp
@@ -9,7 +9,7 @@ define twemproxy::resource::nutcracker4 (
   $server_retry_timeout = '2000',
   $server_failure_limit = '3',
   $redis                = true,
-  
+
   $verbosity            = 6,  # 6-11
 
   $log_dir              = '/var/log/nutcracker',
@@ -18,6 +18,7 @@ define twemproxy::resource::nutcracker4 (
   $statsaddress         = '127.0.0.1',
   $statsport            = 22222,
   $statsinterval        = 30000,  # msec
+  $mbuf                 = 16384,  # default is 16384 bytes recommend 512 bytes
 
   $members              = undef,
 
@@ -64,6 +65,9 @@ define twemproxy::resource::nutcracker4 (
   }
   if !is_integer($statsinterval) {
     fail('$statsinterval must be an integer.')
+  }
+  if !is_integer($mbuf) {
+    fail('$mbuf must be an integer.')
   }
   validate_array($members)
   validate_bool($service_enable)

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppet-twemproxy",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "author": "Paul Gilligan <Paul.Gilligan@moneysupermarket.com>",
   "summary": "This module installs and configures Twemproxy.",
   "license": "Apache-2.0",

--- a/templates/nutcracker-redhat.erb
+++ b/templates/nutcracker-redhat.erb
@@ -20,7 +20,7 @@ CONFFILE=/etc/nutcracker/<%= @name %>.yml
 LOGFILE=/var/log/nutcracker/<%= @name %>.log
 DAEMON=/usr/sbin/nutcracker
 PIDFILE=/var/run/nutcracker/$NAME.pid
-DAEMON_ARGS="-v <%= @verbosity %> -c $CONFFILE -o $LOGFILE -p $PIDFILE -a <%= @statsaddress %> -s <%= @statsport %> -i <%= @statsinterval %> -d"
+DAEMON_ARGS="-v <%= @verbosity %> -c $CONFFILE -m <%= @mbuf %> -o $LOGFILE -p $PIDFILE -a <%= @statsaddress %> -s <%= @statsport %> -i <%= @statsinterval %> -d"
 SCRIPTNAME=/etc/init.d/$NAME
 
 # Source function library.


### PR DESCRIPTION
Release of 0.4.1 and the ability to toggle the mbuf setting applied to twemproxy.

Confluence page shows the perf test results for basline 0.3.0 to 0.4.0 and 0.4.1 with and without mbuf of 512 bytes
https://moneysupermarket.atlassian.net/wiki/display/TSM/Redis+version+3.0.6+and+twemproxy+4.1